### PR TITLE
Try to use zign user before $USER

### DIFF
--- a/piu/cli.py
+++ b/piu/cli.py
@@ -190,7 +190,7 @@ def cli(ctx, config_file):
 def request_access(obj, host, user, password, even_url, odd_host, reason, reason_cont, insecure, lifetime, clip):
     '''Request SSH access to a single host'''
 
-    user = user or os.getenv('USER')
+    user = user or zign.api.get_config().get('user') or os.getenv('USER')
 
     parts = host.split('@')
     if len(parts) > 1:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -87,3 +87,66 @@ def test_oauth_failure(monkeypatch):
 
     assert result.exit_code == 500
     assert 'Server error: **MAGIC-FAIL**' in result.output
+
+def test_login_arg_user(monkeypatch, tmpdir):
+    arg_user = 'arg_user'
+    zign_user = 'zign_user'
+    env_user = 'env_user'
+
+    response = MagicMock()
+
+    runner = CliRunner()
+
+    def mock__request_access(even_url, cacert, username, first_host, reason,
+                           remote_host, lifetime, user, password, clip):
+        assert arg_user == username
+
+    monkeypatch.setattr('zign.api.get_config', lambda: {'user': zign_user})
+    monkeypatch.setattr('os.getenv', lambda x: env_user)
+    monkeypatch.setattr('piu.cli._request_access', mock__request_access)
+    monkeypatch.setattr('requests.get', lambda x, timeout: response)
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(cli, ['request-access', '-U', arg_user],
+                catch_exceptions=False)
+
+
+def test_login_zign_user(monkeypatch, tmpdir):
+    zign_user = 'zign_user'
+    env_user = 'env_user'
+
+    response = MagicMock()
+
+    runner = CliRunner()
+
+    def mock__request_access(even_url, cacert, username, first_host, reason,
+                          remote_host, lifetime, user, password, clip):
+        assert zign_user == username
+
+    monkeypatch.setattr('zign.api.get_config', lambda: {'user': zign_user})
+    monkeypatch.setattr('os.getenv', lambda: env_user)
+    monkeypatch.setattr('piu.cli._request_access', mock__request_access)
+    monkeypatch.setattr('requests.get', lambda x, timeout: response)
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(cli, ['request-access'], catch_exceptions=False)
+
+
+def test_login_env_user(monkeypatch, tmpdir):
+    env_user = 'env_user'
+
+    response = MagicMock()
+
+    runner = CliRunner()
+
+    def mock__request_access(even_url, cacert, username, first_host, reason,
+                          remote_host, lifetime, user, password, clip):
+        assert env_user == username
+
+    monkeypatch.setattr('zign.api.get_config', lambda: {'user': ''})
+    monkeypatch.setattr('os.getenv', lambda x: env_user)
+    monkeypatch.setattr('piu.cli._request_access', mock__request_access)
+    monkeypatch.setattr('requests.get', lambda x, timeout: response)
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(cli, ['request-access'], catch_exceptions=False)


### PR DESCRIPTION
This makes piu use the zign user if it's configured before
defaulting to $USER.

Similar to: https://github.com/zalando-stups/pierone-cli/pull/40

Closes #17
