### PR TITLE
#27 Implementation for tunnel feature

### DIFF
--- a/piu/cli.py
+++ b/piu/cli.py
@@ -210,7 +210,8 @@ def cli(ctx, config_file):
 @click.option('--insecure', help='Do not verify SSL certificate', is_flag=True, default=False)
 @click.option('--clip', help='Copy SSH command into clipboard', is_flag=True, default=False)
 @click.option('--connect', help='Directly connect to the host', envvar='PIU_CONNECT', is_flag=True, default=False)
-@click.option('--tunnel', help='Tunnel to the host', envvar='PIU_TUNNEL', callback=tunnel_validation, metavar='LOCALPORT:REMOTEPORT')
+@click.option('--tunnel', help='Tunnel to the host', envvar='PIU_TUNNEL',
+              callback=tunnel_validation, metavar='LOCALPORT:REMOTEPORT')
 @click.pass_obj
 def request_access(obj, host, reason, reason_cont, user, password, even_url, odd_host, lifetime, interactive,
                    insecure, clip, connect, tunnel):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,6 @@
 
 from click.testing import CliRunner
 from unittest.mock import MagicMock
-import yaml
 import zign.api
 from piu.cli import cli
 
@@ -23,7 +22,14 @@ def test_success(monkeypatch):
     runner = CliRunner()
 
     with runner.isolated_filesystem():
-        result = runner.invoke(cli, ['myuser@127.31.0.1', '--lifetime=15', '--even-url=https://localhost/', '--odd-host=odd.example.org', '--password=foobar', 'my reason'], catch_exceptions=False)
+        result = runner.invoke(cli,
+                               ['myuser@127.31.0.1',
+                                '--lifetime=15',
+                                '--even-url=https://localhost/',
+                                '--odd-host=odd.example.org',
+                                '--password=foobar',
+                                'my reason'],
+                               catch_exceptions=False)
 
     assert response.text in result.output
 
@@ -36,7 +42,14 @@ def test_bad_request(monkeypatch):
     runner = CliRunner()
 
     with runner.isolated_filesystem():
-        result = runner.invoke(cli, ['req', '--lifetime=15', '--even-url=https://localhost/', '--password=foobar', 'myuser@odd-host', 'my reason'], catch_exceptions=False)
+        result = runner.invoke(cli,
+                               ['req',
+                                '--lifetime=15',
+                                '--even-url=https://localhost/',
+                                '--password=foobar',
+                                'myuser@odd-host',
+                                'my reason'],
+                               catch_exceptions=False)
 
     assert response.text in result.output
     assert 'Server returned status 400:' in result.output
@@ -50,7 +63,13 @@ def test_auth_failure(monkeypatch):
     runner = CliRunner()
 
     with runner.isolated_filesystem():
-        result = runner.invoke(cli, ['r', '--even-url=https://localhost/', '--password=invalid', 'myuser@odd-host', 'my reason'], catch_exceptions=False)
+        result = runner.invoke(cli,
+                               ['r',
+                                '--even-url=https://localhost/',
+                                '--password=invalid',
+                                'myuser@odd-host',
+                                'my reason'],
+                               catch_exceptions=False)
 
     assert response.text in result.output
     assert 'Server returned status 403:' in result.output
@@ -67,10 +86,12 @@ def test_dialog(monkeypatch):
     runner = CliRunner()
 
     with runner.isolated_filesystem():
-        result = runner.invoke(cli, ['--config-file=config.yaml', 'req', 'myuser@172.31.0.1', 'my reason'], catch_exceptions=False, input='even\nodd\npassword\n\n')
+        result = runner.invoke(cli, ['--config-file=config.yaml', 'req', 'myuser@172.31.0.1',
+                                     'my reason'], catch_exceptions=False, input='even\nodd\npassword\n\n')
 
     assert result.exit_code == 0
     assert response.text in result.output
+
 
 def test_oauth_failure(monkeypatch):
     response = MagicMock(status_code=200, text='**MAGIC-SUCCESS**')
@@ -83,10 +104,12 @@ def test_oauth_failure(monkeypatch):
     runner = CliRunner()
 
     with runner.isolated_filesystem():
-        result = runner.invoke(cli, ['--config-file=config.yaml', 'req', 'myuser@172.31.0.1', 'my reason'], catch_exceptions=False, input='even\nodd\npassword\n\n')
+        result = runner.invoke(cli, ['--config-file=config.yaml', 'req', 'myuser@172.31.0.1',
+                                     'my reason'], catch_exceptions=False, input='even\nodd\npassword\n\n')
 
     assert result.exit_code == 500
     assert 'Server error: **MAGIC-FAIL**' in result.output
+
 
 def test_login_arg_user(monkeypatch, tmpdir):
     arg_user = 'arg_user'
@@ -98,7 +121,7 @@ def test_login_arg_user(monkeypatch, tmpdir):
     runner = CliRunner()
 
     def mock__request_access(even_url, cacert, username, first_host, reason,
-                           remote_host, lifetime, user, password, clip):
+                             remote_host, lifetime, user, password, clip):
         assert arg_user == username
 
     monkeypatch.setattr('zign.api.get_config', lambda: {'user': zign_user})
@@ -107,8 +130,7 @@ def test_login_arg_user(monkeypatch, tmpdir):
     monkeypatch.setattr('requests.get', lambda x, timeout: response)
 
     with runner.isolated_filesystem():
-        result = runner.invoke(cli, ['request-access', '-U', arg_user],
-                catch_exceptions=False)
+        runner.invoke(cli, ['request-access', '-U', arg_user], catch_exceptions=False)
 
 
 def test_login_zign_user(monkeypatch, tmpdir):
@@ -120,7 +142,7 @@ def test_login_zign_user(monkeypatch, tmpdir):
     runner = CliRunner()
 
     def mock__request_access(even_url, cacert, username, first_host, reason,
-                          remote_host, lifetime, user, password, clip):
+                             remote_host, lifetime, user, password, clip):
         assert zign_user == username
 
     monkeypatch.setattr('zign.api.get_config', lambda: {'user': zign_user})
@@ -129,7 +151,7 @@ def test_login_zign_user(monkeypatch, tmpdir):
     monkeypatch.setattr('requests.get', lambda x, timeout: response)
 
     with runner.isolated_filesystem():
-        result = runner.invoke(cli, ['request-access'], catch_exceptions=False)
+        runner.invoke(cli, ['request-access'], catch_exceptions=False)
 
 
 def test_login_env_user(monkeypatch, tmpdir):
@@ -140,7 +162,7 @@ def test_login_env_user(monkeypatch, tmpdir):
     runner = CliRunner()
 
     def mock__request_access(even_url, cacert, username, first_host, reason,
-                          remote_host, lifetime, user, password, clip):
+                             remote_host, lifetime, user, password, clip):
         assert env_user == username
 
     monkeypatch.setattr('zign.api.get_config', lambda: {'user': ''})
@@ -149,7 +171,7 @@ def test_login_env_user(monkeypatch, tmpdir):
     monkeypatch.setattr('requests.get', lambda x, timeout: response)
 
     with runner.isolated_filesystem():
-        result = runner.invoke(cli, ['request-access'], catch_exceptions=False)
+        runner.invoke(cli, ['request-access'], catch_exceptions=False)
 
 
 def test_interactive_success(monkeypatch):
@@ -157,10 +179,19 @@ def test_interactive_success(monkeypatch):
     request_access = MagicMock()
 
     response = []
-    response.append(MagicMock(**{'instance_id': 'i-123456', 'private_ip_address': '172.31.10.10', 'tags': [{'Key': 'Name', 'Value': 'stack1-0o1o0'}, {'Key': 'StackVersion', 'Value': '0o1o0'}, {'Key': 'StackName', 'Value': 'stack1'}]}))
-    response.append(MagicMock(**{'instance_id': 'i-789012', 'private_ip_address': '172.31.10.20', 'tags': [{'Key': 'Name', 'Value': 'stack2-0o1o0'}, {'Key': 'StackVersion', 'Value': '0o2o0'}, {'Key': 'StackName', 'Value': 'stack2'}]}))
+    response.append(MagicMock(**{'instance_id': 'i-123456',
+                                 'private_ip_address': '172.31.10.10',
+                                 'tags': [{'Key': 'Name', 'Value': 'stack1-0o1o0'},
+                                          {'Key': 'StackVersion', 'Value': '0o1o0'},
+                                          {'Key': 'StackName', 'Value': 'stack1'}]
+                                 }))
+    response.append(MagicMock(**{'instance_id': 'i-789012',
+                                 'private_ip_address': '172.31.10.20',
+                                 'tags': [{'Key': 'Name', 'Value': 'stack2-0o1o0'},
+                                          {'Key': 'StackVersion', 'Value': '0o2o0'},
+                                          {'Key': 'StackName', 'Value': 'stack2'}]
+                                 }))
     ec2.instances.filter = MagicMock(return_value=response)
-    boto3 = MagicMock()
     monkeypatch.setattr('boto3.resource', MagicMock(return_value=ec2))
     monkeypatch.setattr('piu.cli._request_access', MagicMock(side_effect=request_access))
 
@@ -168,7 +199,13 @@ def test_interactive_success(monkeypatch):
     input_stream = '\n'.join(['eu-west-1', '1', 'Troubleshooting']) + '\n'
 
     with runner.isolated_filesystem():
-        result = runner.invoke(cli, ['request-access', '--interactive', '--even-url=https://localhost/', '--odd-host=odd.example.org'], input=input_stream, catch_exceptions=False)
+        runner.invoke(cli,
+                      ['request-access',
+                       '--interactive',
+                       '--even-url=https://localhost/',
+                       '--odd-host=odd.example.org'],
+                      input=input_stream,
+                      catch_exceptions=False)
 
     assert request_access.called
 
@@ -178,9 +215,13 @@ def test_interactive_single_instance_success(monkeypatch):
     request_access = MagicMock()
 
     response = []
-    response.append(MagicMock(**{'instance_id': 'i-123456', 'private_ip_address': '172.31.10.10', 'tags': [{'Key': 'Name', 'Value': 'stack1-0o1o0'}, {'Key': 'StackVersion', 'Value': '0o1o0'}, {'Key': 'StackName', 'Value': 'stack1'}]}))
+    response.append(MagicMock(**{'instance_id': 'i-123456',
+                                 'private_ip_address': '172.31.10.10',
+                                 'tags': [{'Key': 'Name', 'Value': 'stack1-0o1o0'},
+                                          {'Key': 'StackVersion', 'Value': '0o1o0'},
+                                          {'Key': 'StackName', 'Value': 'stack1'}]
+                                 }))
     ec2.instances.filter = MagicMock(return_value=response)
-    boto3 = MagicMock()
     monkeypatch.setattr('boto3.resource', MagicMock(return_value=ec2))
     monkeypatch.setattr('piu.cli._request_access', MagicMock(side_effect=request_access))
 
@@ -188,7 +229,13 @@ def test_interactive_single_instance_success(monkeypatch):
     input_stream = '\n'.join(['eu-west-1', '', 'Troubleshooting']) + '\n'
 
     with runner.isolated_filesystem():
-        result = runner.invoke(cli, ['request-access', '--interactive', '--even-url=https://localhost/', '--odd-host=odd.example.org'], input=input_stream, catch_exceptions=False)
+        runner.invoke(cli,
+                      ['request-access',
+                       '--interactive',
+                       '--even-url=https://localhost/',
+                       '--odd-host=odd.example.org'],
+                      input=input_stream,
+                      catch_exceptions=False)
 
     assert request_access.called
 
@@ -199,7 +246,6 @@ def test_interactive_no_instances_failure(monkeypatch):
 
     response = []
     ec2.instances.filter = MagicMock(return_value=response)
-    boto3 = MagicMock()
     monkeypatch.setattr('boto3.resource', MagicMock(return_value=ec2))
     monkeypatch.setattr('piu.cli._request_access', MagicMock(side_effect=request_access))
 
@@ -207,34 +253,53 @@ def test_interactive_no_instances_failure(monkeypatch):
     input_stream = '\neu-west-1\n'
 
     with runner.isolated_filesystem():
-        result = runner.invoke(cli, ['request-access', '--interactive', '--even-url=https://localhost/', '--odd-host=odd.example.org'], input=input_stream, catch_exceptions=False)
+        result = runner.invoke(cli,
+                               ['request-access',
+                                '--interactive',
+                                '--even-url=https://localhost/',
+                                '--odd-host=odd.example.org'],
+                               input=input_stream,
+                               catch_exceptions=False)
 
     assert result.exception
     assert 'Error: No running instances were found.' in result.output
+
 
 def test_tunnel_either_connect_or_tunnel():
     input_stream = '\neu-central-1\n'
 
     runner = CliRunner()
     with runner.isolated_filesystem():
-        result = runner.invoke(cli, ['request-access', '--connect', '--tunnel', 'myuser@somehost.example.org', 'Testing'], input=input_stream, catch_exceptions=False)
+        result = runner.invoke(cli,
+                               ['request-access',
+                                '--connect',
+                                '--tunnel',
+                                'myuser@somehost.example.org',
+                                'Testing'],
+                               input=input_stream,
+                               catch_exceptions=False)
     assert result.exception
     assert 'Cannot specify both "connect" and "tunnel"'
+
 
 def test_tunnel_should_have_correct_format():
 
     runner = CliRunner()
     with runner.isolated_filesystem():
-        result = runner.invoke(cli, ['request-access', '--tunnel','a2345:234a', 'myuser@somehost.example.org', 'Testing'], catch_exceptions=False)
+        result = runner.invoke(cli, ['request-access', '--tunnel', 'a2345:234a',
+                                     'myuser@somehost.example.org', 'Testing'], catch_exceptions=False)
     assert result.exception
 
     with runner.isolated_filesystem():
-        result = runner.invoke(cli, ['request-access', '--tunnel','23434', 'myuser@somehost.example.org', 'Testing'], catch_exceptions=False)
+        result = runner.invoke(cli, ['request-access', '--tunnel', '23434',
+                                     'myuser@somehost.example.org', 'Testing'], catch_exceptions=False)
     assert result.exception
 
     with runner.isolated_filesystem():
-        result = runner.invoke(cli, ['request-access', '--tunnel','a2345:2343', 'myuser@somehost.example.org', 'Testing'], catch_exceptions=False)
+        result = runner.invoke(cli, ['request-access', '--tunnel', 'a2345:2343',
+                                     'myuser@somehost.example.org', 'Testing'], catch_exceptions=False)
     assert result.exception
+
 
 def test_tunnel_success(monkeypatch):
 
@@ -246,8 +311,13 @@ def test_tunnel_success(monkeypatch):
 
     runner = CliRunner()
     with runner.isolated_filesystem():
-        result = runner.invoke(cli, ['request-access', '--tunnel','2380:2379', '--even-url=https://localhost/', 
-                '--odd-host=odd.example.org', 'myuser@somehost.example.org', 'Testing'], catch_exceptions=False)
+        result = runner.invoke(cli, ['request-access',
+                                     '--tunnel', '2380:2379',
+                                     '--even-url=https://localhost/',
+                                     '--odd-host=odd.example.org',
+                                     'myuser@somehost.example.org',
+                                     'Testing'],
+                               catch_exceptions=False)
 
     assert response.text in result.output
     assert '-L 2380:somehost.example.org:2379' in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -246,7 +246,8 @@ def test_tunnel_success(monkeypatch):
 
     runner = CliRunner()
     with runner.isolated_filesystem():
-        result = runner.invoke(cli, ['request-access', '--tunnel','2380:2379', 'myuser@somehost.example.org', 'Testing'], catch_exceptions=False)
+        result = runner.invoke(cli, ['request-access', '--tunnel','2380:2379', '--even-url=https://localhost/', 
+                '--odd-host=odd.example.org', 'myuser@somehost.example.org', 'Testing'], catch_exceptions=False)
 
     assert response.text in result.output
     assert '-L 2380:somehost.example.org:2379' in result.output


### PR DESCRIPTION
Add --tunnel option which can be used instead of --connect.
Takes LocalPort:RemotePort as argument and works with normal as well as interactive mode.
