### PR TITLE
Autodetect odd host

### DIFF
--- a/piu/error_handling.py
+++ b/piu/error_handling.py
@@ -34,7 +34,7 @@ def handle_exceptions(func):
         try:
             func()
         except NoCredentialsError as e:
-            print('No AWS credentials found. Use the "mai" command-line tool to get a temporary access key\n'
+            print('No AWS credentials found. Use the "zaws" command-line tool to get a temporary access key\n'
                   'or manually configure either ~/.aws/credentials or AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY.',
                   file=sys.stderr)
             sys.exit(1)
@@ -42,7 +42,7 @@ def handle_exceptions(func):
             sys.stdout.flush()
             if is_credentials_expired_error(e):
                 print('AWS credentials have expired.\n'
-                      'Use the "mai" command line tool to get a new temporary access key.',
+                      'Use the "zaws" command line tool to get a new temporary access key.',
                       file=sys.stderr)
                 sys.exit(1)
             else:

--- a/piu/utils.py
+++ b/piu/utils.py
@@ -1,0 +1,44 @@
+import boto3
+import click
+
+
+def _hosted_zones(route53):
+    """Enumerates all Route53 hosted zones as tuples of id, name"""
+
+    paginator = route53.get_paginator('list_hosted_zones')
+    for result in paginator.paginate():
+        for zone in result['HostedZones']:
+            yield zone['Id'], zone['Name']
+
+
+def find_odd_host(region):
+    """Returns the Odd SSH bastion hostname for the current AWS account and the
+       specified region if it exists"""
+    if not region:
+        return
+
+    route53 = boto3.client('route53', region_name=region)
+    for zone_id, zone_name in _hosted_zones(route53):
+        candidate_host = "odd-{}.{}".format(region, zone_name)
+        result = route53.list_resource_record_sets(
+            HostedZoneId=zone_id, MaxItems='1',
+            StartRecordType='A', StartRecordName=candidate_host)
+        for record in result['ResourceRecordSets']:
+            if record['Type'] == 'A' and record['Name'] == candidate_host:
+                return record['Name'].rstrip('.')
+
+
+def current_region():
+    """Returns the current AWS region"""
+    session = boto3.session.Session()
+    return session.region_name
+
+
+def validate_region(ctx, param, value):
+    """Click validator for the AWS region argument"""
+    if value is not None:
+        session = boto3.session.Session()
+        if value not in session.get_available_regions('cloudformation'):
+            raise click.BadParameter("Invalid AWS region '{}'".format(value))
+
+    return value

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -119,6 +119,35 @@ def mock_request_access(monkeypatch, expected_user=None, expected_odd_host=None)
     monkeypatch.setattr('piu.cli._request_access', mock_fn)
 
 
+def test_bastion_arg_host(monkeypatch):
+    monkeypatch.setattr('piu.cli.load_config', lambda _: {"even_url": "https://even.example.org",
+                                                          "odd_host": "odd-config.example.org"})
+
+    mock_request_access(monkeypatch, expected_odd_host='odd-arg.example.org')
+
+    expect_success(['request-access', '-O', 'odd-arg.example.org', 'user@host.example.org', 'reason'],
+                   catch_exceptions=False)
+
+
+def test_bastion_autodetect_host(monkeypatch):
+    monkeypatch.setattr('piu.utils.find_odd_host', lambda region: "odd-auto.example.org")
+    monkeypatch.setattr('piu.cli.load_config', lambda file: {"even_url": "https://even.example.org",
+                                                             "odd_host": "odd-config.example.org"})
+
+    mock_request_access(monkeypatch, expected_odd_host='odd-auto.example.org')
+
+    expect_success(['request-access', 'user@host.example.org', 'reason'], catch_exceptions=False)
+
+
+def test_bastion_config_host(monkeypatch):
+    monkeypatch.setattr('piu.cli.load_config', lambda file: {"even_url": "https://even.example.org",
+                                                             "odd_host": "odd-config.example.org"})
+
+    mock_request_access(monkeypatch, expected_odd_host='odd-config.example.org')
+
+    expect_success(['request-access', 'user@host.example.org', 'reason'], catch_exceptions=False)
+
+
 def test_login_zign_user(monkeypatch):
     zign_user = 'zign_user'
     env_user = 'env_user'

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -155,6 +155,8 @@ def test_login_zign_user(monkeypatch):
     response = MagicMock()
 
     monkeypatch.setattr('zign.api.get_config', lambda: {'user': zign_user})
+    monkeypatch.setattr('piu.cli.load_config', lambda file: {"even_url": "https://even.example.org",
+                                                             "odd_host": "odd-config.example.org"})
     monkeypatch.setattr('os.getenv', lambda: env_user)
     mock_request_access(monkeypatch, expected_user=zign_user)
     monkeypatch.setattr('requests.get', lambda x, timeout: response)
@@ -168,6 +170,8 @@ def test_login_env_user(monkeypatch):
     response = MagicMock()
 
     monkeypatch.setattr('zign.api.get_config', lambda: {'user': ''})
+    monkeypatch.setattr('piu.cli.load_config', lambda file: {"even_url": "https://even.example.org",
+                                                             "odd_host": "odd-config.example.org"})
     monkeypatch.setattr('os.getenv', lambda x: env_user)
     mock_request_access(monkeypatch, expected_user=env_user)
     monkeypatch.setattr('requests.get', lambda x, timeout: response)
@@ -182,6 +186,8 @@ def test_login_arg_user(monkeypatch, tmpdir):
     response = MagicMock()
 
     monkeypatch.setattr('zign.api.get_config', lambda: {'user': zign_user})
+    monkeypatch.setattr('piu.cli.load_config', lambda file: {"even_url": "https://even.example.org",
+                                                             "odd_host": "odd-config.example.org"})
     monkeypatch.setattr('os.getenv', lambda x: env_user)
     mock_request_access(monkeypatch, expected_user='arg_user')
     monkeypatch.setattr('requests.get', lambda x, timeout: response)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,3 @@
-
 from click.testing import CliRunner
 from unittest.mock import MagicMock
 import zign.api
@@ -6,19 +5,28 @@ from piu.cli import cli
 import pytest
 
 
-@pytest.yield_fixture(autouse=True)
+@pytest.fixture(autouse=True)
 def mock_aws(monkeypatch):
-  monkeypatch.setattr('piu.utils.current_region', lambda: 'eu-central-1')
-  monkeypatch.setattr('piu.utils.find_odd_host', lambda region: None)
-  yield
+    monkeypatch.setattr('piu.utils.current_region', lambda: 'eu-central-1')
+    monkeypatch.setattr('piu.utils.find_odd_host', lambda region: None)
+    yield
+
+
+@pytest.fixture(autouse=True)
+def prevent_config_overwrite(monkeypatch):
+    monkeypatch.setattr('piu.cli.store_config', lambda config, path: None)
+
+
+def expect_success(args, **kwargs):
+    result = CliRunner().invoke(cli, args, **kwargs)
+    print(result.output)
+    assert result.exit_code == 0
+    return result
 
 
 def test_missing_reason():
     runner = CliRunner()
-
-    with runner.isolated_filesystem():
-        result = runner.invoke(cli, ['myuser@somehost.example.org'], catch_exceptions=False)
-
+    result = runner.invoke(cli, ['myuser@somehost.example.org'], catch_exceptions=False)
     assert 'Missing argument "reason"' in result.output
 
 
@@ -26,16 +34,13 @@ def test_success(monkeypatch):
     response = MagicMock(status_code=200, text='**MAGIC-SUCCESS**')
     monkeypatch.setattr('zign.api.get_token', MagicMock(return_value='123'))
     monkeypatch.setattr('requests.post', MagicMock(return_value=response))
-    runner = CliRunner()
 
-    with runner.isolated_filesystem():
-        result = runner.invoke(cli,
-                               ['myuser@127.31.0.1',
-                                '--lifetime=15',
-                                '--even-url=https://localhost/',
-                                '--odd-host=odd.example.org',
-                                'my reason'],
-                               catch_exceptions=False)
+    result = expect_success(['myuser@127.31.0.1',
+                             '--lifetime=15',
+                             '--even-url=https://localhost/',
+                             '--odd-host=odd.example.org',
+                             'my reason'],
+                            catch_exceptions=False)
 
     assert response.text in result.output
 
@@ -46,14 +51,13 @@ def test_bad_request(monkeypatch):
     monkeypatch.setattr('requests.post', MagicMock(return_value=response))
     runner = CliRunner()
 
-    with runner.isolated_filesystem():
-        result = runner.invoke(cli,
-                               ['req',
-                                '--lifetime=15',
-                                '--even-url=https://localhost/',
-                                'myuser@odd-host',
-                                'my reason'],
-                               catch_exceptions=False)
+    result = runner.invoke(cli,
+                           ['req',
+                            '--lifetime=15',
+                            '--even-url=https://localhost/',
+                            'myuser@odd-host',
+                            'my reason'],
+                           catch_exceptions=False)
 
     assert response.text in result.output
     assert 'Server returned status 400:' in result.output
@@ -65,13 +69,12 @@ def test_auth_failure(monkeypatch):
     monkeypatch.setattr('requests.post', MagicMock(return_value=response))
     runner = CliRunner()
 
-    with runner.isolated_filesystem():
-        result = runner.invoke(cli,
-                               ['r',
-                                '--even-url=https://localhost/',
-                                'myuser@odd-host',
-                                'my reason'],
-                               catch_exceptions=False)
+    result = runner.invoke(cli,
+                           ['r',
+                            '--even-url=https://localhost/',
+                            'myuser@odd-host',
+                            'my reason'],
+                           catch_exceptions=False)
 
     assert response.text in result.output
     assert 'Server returned status 403:' in result.output
@@ -83,13 +86,9 @@ def test_dialog(monkeypatch):
     monkeypatch.setattr('requests.post', MagicMock(return_value=response))
     monkeypatch.setattr('requests.get', MagicMock(return_value=response))
     monkeypatch.setattr('socket.getaddrinfo', MagicMock())
-    runner = CliRunner()
 
-    with runner.isolated_filesystem():
-        result = runner.invoke(cli, ['--config-file=config.yaml', 'req', 'myuser@172.31.0.1',
-                                     'my reason'], catch_exceptions=False, input='even\nodd\npassword\n\n')
-
-    assert result.exit_code == 0
+    result = expect_success(['--config-file=config.yaml', 'req', 'myuser@172.31.0.1',
+                             'my reason'], catch_exceptions=False, input='even\nodd\npassword\n\n')
     assert response.text in result.output
 
 
@@ -101,80 +100,69 @@ def test_oauth_failure(monkeypatch):
     monkeypatch.setattr('socket.getaddrinfo', MagicMock())
     runner = CliRunner()
 
-    with runner.isolated_filesystem():
-        result = runner.invoke(cli, ['--config-file=config.yaml', 'req', 'myuser@172.31.0.1',
-                                     'my reason'], catch_exceptions=False, input='even\nodd\npassword\n\n')
+    result = runner.invoke(cli, ['--config-file=config.yaml', 'req', 'myuser@172.31.0.1',
+                                 'my reason'], catch_exceptions=False, input='even\nodd\npassword\n\n')
 
     assert result.exit_code == 500
     assert 'Server error: **MAGIC-FAIL**' in result.output
 
 
-def test_login_arg_user(monkeypatch, tmpdir):
-    arg_user = 'arg_user'
+def mock_request_access(monkeypatch, expected_user=None, expected_odd_host=None):
+    def mock_fn(even_url, cacert, username, odd_host, reason,
+                remote_host, lifetime, user, password, clip):
+        if expected_user:
+            assert expected_user == username
+        if expected_odd_host:
+            assert expected_odd_host == odd_host
+        return 200
+
+    monkeypatch.setattr('piu.cli._request_access', mock_fn)
+
+
+def test_login_zign_user(monkeypatch):
     zign_user = 'zign_user'
     env_user = 'env_user'
 
     response = MagicMock()
-
-    runner = CliRunner()
-
-    def mock__request_access(even_url, cacert, username, first_host, reason,
-                             remote_host, lifetime, user, password, clip):
-        assert arg_user == username
-
-    monkeypatch.setattr('zign.api.get_config', lambda: {'user': zign_user})
-    monkeypatch.setattr('os.getenv', lambda x: env_user)
-    monkeypatch.setattr('piu.cli._request_access', mock__request_access)
-    monkeypatch.setattr('requests.get', lambda x, timeout: response)
-
-    with runner.isolated_filesystem():
-        runner.invoke(cli, ['request-access', '-U', arg_user], catch_exceptions=False)
-
-
-def test_login_zign_user(monkeypatch, tmpdir):
-    zign_user = 'zign_user'
-    env_user = 'env_user'
-
-    response = MagicMock()
-
-    runner = CliRunner()
-
-    def mock__request_access(even_url, cacert, username, first_host, reason,
-                             remote_host, lifetime, user, password, clip):
-        assert zign_user == username
 
     monkeypatch.setattr('zign.api.get_config', lambda: {'user': zign_user})
     monkeypatch.setattr('os.getenv', lambda: env_user)
-    monkeypatch.setattr('piu.cli._request_access', mock__request_access)
+    mock_request_access(monkeypatch, expected_user=zign_user)
     monkeypatch.setattr('requests.get', lambda x, timeout: response)
 
-    with runner.isolated_filesystem():
-        runner.invoke(cli, ['request-access'], catch_exceptions=False)
+    expect_success(['request-access', 'host.example.org', 'reason'], catch_exceptions=False)
 
 
-def test_login_env_user(monkeypatch, tmpdir):
+def test_login_env_user(monkeypatch):
     env_user = 'env_user'
 
     response = MagicMock()
 
-    runner = CliRunner()
-
-    def mock__request_access(even_url, cacert, username, first_host, reason,
-                             remote_host, lifetime, user, password, clip):
-        assert env_user == username
-
     monkeypatch.setattr('zign.api.get_config', lambda: {'user': ''})
     monkeypatch.setattr('os.getenv', lambda x: env_user)
-    monkeypatch.setattr('piu.cli._request_access', mock__request_access)
+    mock_request_access(monkeypatch, expected_user=env_user)
     monkeypatch.setattr('requests.get', lambda x, timeout: response)
 
-    with runner.isolated_filesystem():
-        runner.invoke(cli, ['request-access'], catch_exceptions=False)
+    expect_success(['request-access', 'host.example.org', 'reason'], catch_exceptions=False)
+
+
+def test_login_arg_user(monkeypatch, tmpdir):
+    zign_user = 'zign_user'
+    env_user = 'env_user'
+
+    response = MagicMock()
+
+    monkeypatch.setattr('zign.api.get_config', lambda: {'user': zign_user})
+    monkeypatch.setattr('os.getenv', lambda x: env_user)
+    mock_request_access(monkeypatch, expected_user='arg_user')
+    monkeypatch.setattr('requests.get', lambda x, timeout: response)
+
+    expect_success(['request-access', 'arg_user@host.example.org', 'reason'], catch_exceptions=False)
 
 
 def test_interactive_success(monkeypatch):
     ec2 = MagicMock()
-    request_access = MagicMock()
+    request_access = MagicMock(return_value=200)
 
     response = []
     response.append(MagicMock(**{'instance_id': 'i-123456',
@@ -191,26 +179,23 @@ def test_interactive_success(monkeypatch):
                                  }))
     ec2.instances.filter = MagicMock(return_value=response)
     monkeypatch.setattr('boto3.resource', MagicMock(return_value=ec2))
-    monkeypatch.setattr('piu.cli._request_access', MagicMock(side_effect=request_access))
+    monkeypatch.setattr('piu.cli._request_access', request_access)
 
-    runner = CliRunner()
     input_stream = '\n'.join(['eu-west-1', 'odd-eu-west-1.test.example.org', '1', 'Troubleshooting']) + '\n'
 
-    with runner.isolated_filesystem():
-        runner.invoke(cli,
-                      ['request-access',
-                       '--interactive',
-                       '--even-url=https://localhost/',
-                       '--odd-host=odd.example.org'],
-                      input=input_stream,
-                      catch_exceptions=False)
+    expect_success(['request-access',
+                    '--interactive',
+                    '--even-url=https://localhost/',
+                    '--odd-host=odd.example.org'],
+                   input=input_stream,
+                   catch_exceptions=False)
 
     assert request_access.called
 
 
 def test_interactive_single_instance_success(monkeypatch):
     ec2 = MagicMock()
-    request_access = MagicMock()
+    request_access = MagicMock(return_value=200)
 
     response = []
     response.append(MagicMock(**{'instance_id': 'i-123456',
@@ -221,19 +206,16 @@ def test_interactive_single_instance_success(monkeypatch):
                                  }))
     ec2.instances.filter = MagicMock(return_value=response)
     monkeypatch.setattr('boto3.resource', MagicMock(return_value=ec2))
-    monkeypatch.setattr('piu.cli._request_access', MagicMock(side_effect=request_access))
+    monkeypatch.setattr('piu.cli._request_access', request_access)
 
-    runner = CliRunner()
     input_stream = '\n'.join(['eu-west-1', '', 'Troubleshooting']) + '\n'
 
-    with runner.isolated_filesystem():
-        runner.invoke(cli,
-                      ['request-access',
-                       '--interactive',
-                       '--even-url=https://localhost/',
-                       '--odd-host=odd.example.org'],
-                      input=input_stream,
-                      catch_exceptions=False)
+    expect_success(['request-access',
+                    '--interactive',
+                    '--even-url=https://localhost/',
+                    '--odd-host=odd.example.org'],
+                   input=input_stream,
+                   catch_exceptions=False)
 
     assert request_access.called
 
@@ -250,14 +232,13 @@ def test_interactive_no_instances_failure(monkeypatch):
     runner = CliRunner()
     input_stream = '\neu-west-1\n'
 
-    with runner.isolated_filesystem():
-        result = runner.invoke(cli,
-                               ['request-access',
-                                '--interactive',
-                                '--even-url=https://localhost/',
-                                '--odd-host=odd.example.org'],
-                               input=input_stream,
-                               catch_exceptions=False)
+    result = runner.invoke(cli,
+                           ['request-access',
+                            '--interactive',
+                            '--even-url=https://localhost/',
+                            '--odd-host=odd.example.org'],
+                           input=input_stream,
+                           catch_exceptions=False)
 
     assert result.exception
     assert 'Error: No running instances were found.' in result.output
@@ -267,15 +248,14 @@ def test_tunnel_either_connect_or_tunnel():
     input_stream = '\neu-central-1\n'
 
     runner = CliRunner()
-    with runner.isolated_filesystem():
-        result = runner.invoke(cli,
-                               ['request-access',
-                                '--connect',
-                                '--tunnel',
-                                'myuser@somehost.example.org',
-                                'Testing'],
-                               input=input_stream,
-                               catch_exceptions=False)
+    result = runner.invoke(cli,
+                           ['request-access',
+                            '--connect',
+                            '--tunnel',
+                            'myuser@somehost.example.org',
+                            'Testing'],
+                           input=input_stream,
+                           catch_exceptions=False)
     assert result.exception
     assert 'Cannot specify both "connect" and "tunnel"'
 
@@ -283,19 +263,19 @@ def test_tunnel_either_connect_or_tunnel():
 def test_tunnel_should_have_correct_format():
 
     runner = CliRunner()
-    with runner.isolated_filesystem():
-        result = runner.invoke(cli, ['request-access', '--tunnel', 'a2345:234a',
-                                     'myuser@somehost.example.org', 'Testing'], catch_exceptions=False)
+    result = runner.invoke(cli, ['request-access', '--tunnel', 'a2345:234a',
+                                 'myuser@somehost.example.org', 'Testing'],
+                           catch_exceptions=False)
     assert result.exception
 
-    with runner.isolated_filesystem():
-        result = runner.invoke(cli, ['request-access', '--tunnel', '23434',
-                                     'myuser@somehost.example.org', 'Testing'], catch_exceptions=False)
+    result = runner.invoke(cli, ['request-access', '--tunnel', '23434',
+                                 'myuser@somehost.example.org', 'Testing'],
+                           catch_exceptions=False)
     assert result.exception
 
-    with runner.isolated_filesystem():
-        result = runner.invoke(cli, ['request-access', '--tunnel', 'a2345:2343',
-                                     'myuser@somehost.example.org', 'Testing'], catch_exceptions=False)
+    result = runner.invoke(cli, ['request-access', '--tunnel', 'a2345:2343',
+                                 'myuser@somehost.example.org', 'Testing'],
+                           catch_exceptions=False)
     assert result.exception
 
 
@@ -307,15 +287,13 @@ def test_tunnel_success(monkeypatch):
     monkeypatch.setattr('requests.post', MagicMock(return_value=response))
     monkeypatch.setattr('subprocess.call', MagicMock())
 
-    runner = CliRunner()
-    with runner.isolated_filesystem():
-        result = runner.invoke(cli, ['request-access',
-                                     '--tunnel', '2380:2379',
-                                     '--even-url=https://localhost/',
-                                     '--odd-host=odd.example.org',
-                                     'myuser@somehost.example.org',
-                                     'Testing'],
-                               catch_exceptions=False)
+    result = expect_success(['request-access',
+                             '--tunnel', '2380:2379',
+                             '--even-url=https://localhost/',
+                             '--odd-host=odd.example.org',
+                             'myuser@somehost.example.org',
+                             'Testing'],
+                            catch_exceptions=False)
 
     assert response.text in result.output
     assert '-L 2380:somehost.example.org:2379' in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,14 @@ from click.testing import CliRunner
 from unittest.mock import MagicMock
 import zign.api
 from piu.cli import cli
+import pytest
+
+
+@pytest.yield_fixture(autouse=True)
+def mock_aws(monkeypatch):
+  monkeypatch.setattr('piu.utils.current_region', lambda: 'eu-central-1')
+  monkeypatch.setattr('piu.utils.find_odd_host', lambda region: None)
+  yield
 
 
 def test_missing_reason():
@@ -186,7 +194,7 @@ def test_interactive_success(monkeypatch):
     monkeypatch.setattr('piu.cli._request_access', MagicMock(side_effect=request_access))
 
     runner = CliRunner()
-    input_stream = '\n'.join(['eu-west-1', '1', 'Troubleshooting']) + '\n'
+    input_stream = '\n'.join(['eu-west-1', 'odd-eu-west-1.test.example.org', '1', 'Troubleshooting']) + '\n'
 
     with runner.isolated_filesystem():
         runner.invoke(cli,


### PR DESCRIPTION
 * Port Odd host detection logic ported from `senza -p`. If the Odd host isn't specified with -O, try to determine it by looking for it in the available Route53 hosted zones. Only ask the user or fallback to the config value if we can't find anything.
 * Fix and cleanup the tests.