### PR TITLE
Add a reminder to ssh-add

### DIFF
--- a/piu/cli.py
+++ b/piu/cli.py
@@ -182,7 +182,7 @@ def _request_access(even_url, cacert, username, hostname, reason, remote_host,
         if connect or tunnel:
             subprocess.call(command.split())
 
-        click.secho("Don't forget to add your SSH to SSH Agent, for example:")
+        click.secho("Don't forget to add your SSH private key to SSH Agent, for example:")
         click.secho('ssh-add ~/.ssh/id_rsa')
         click.secho('You can access your server with the following command:')
         click.secho(command)

--- a/piu/cli.py
+++ b/piu/cli.py
@@ -182,6 +182,8 @@ def _request_access(even_url, cacert, username, hostname, reason, remote_host,
         if connect or tunnel:
             subprocess.call(command.split())
 
+        click.secho("Don't forget to add your SSH to SSH Agent, for example:")
+        click.secho('ssh-add ~/.ssh/id_rsa')
         click.secho('You can access your server with the following command:')
         click.secho(command)
 


### PR DESCRIPTION
I tripped on this multiple times, without adding the key to SSH Agent `ssh` just says "Permission denied (public key)".

This additional message would have helped.