### PR TITLE
Updated the boto3 requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ PyYAML
 requests
 pyperclip
 stups-zign>=1.1.26
-boto3>=1.3.0
+boto3>=1.12.0
 botocore>=1.4.10
 click>=1.2.2


### PR DESCRIPTION
The version in the `requirements.txt` does not support EIC which was introduced in #46 