### PR TITLE
Drop even support completely

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -128,7 +128,7 @@ def setup_package():
         test_suite="tests",
         packages=setuptools.find_packages(exclude=["tests", "tests.*"]),
         install_requires=install_reqs,
-        setup_requires=["six", "black"],
+        setup_requires=["six", "black", "wheel"],
         cmdclass=cmdclass,
         tests_require=["pytest-cov", "pytest"],
         command_options=command_options,


### PR DESCRIPTION
We don't have an even instance anymore, so let's drop all related code. This also fixes an issue where piu still asks for the even URL with an empty config.

In addition to that, the EIC path is updated to put the request reason into the User-Agent header (seems to be the only way to make it visible in CloudTrail).